### PR TITLE
Add missing values in update order status

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ $update = Konduto::updateOrderStatus("ORD1237163", "approved", "Comments about t
 
 Parameter | Description
 --- | ---
-status | _(required)_ New status for this transaction. Either `approved`, `declined` or `fraud`, when you have identified a fraud or chargeback.
+status | _(required)_ New status for this transaction. Either `approved`, `declined`, `fraud`, `canceled` or `not_authorized`, when you have identified a fraud or chargeback.
 comments | _(required)_ Reason or comments about the status update.
 
 ## Query an order

--- a/src/Core/Konduto.php
+++ b/src/Core/Konduto.php
@@ -132,7 +132,7 @@ abstract class Konduto extends ApiControl {
      * is required to improve Konduto recommendation algorithm.
      *
      * @param order_id id of the order being updated
-     * @param status string containing 'approved', 'declined' or 'fraud'
+     * @param status string containing 'approved', 'declined', 'fraud', 'canceled' or 'not_authorized'
      * @param comments string containing comments of why the status is being updated as so
      *
      * @throws InvalidOrderException if the provided order_id or status are not valid
@@ -141,7 +141,7 @@ abstract class Konduto extends ApiControl {
      */
     public static function updateOrderStatus($order_id, $status, $comments = "") {
 
-        if (!in_array($status, array(Models\STATUS_APPROVED, Models\STATUS_DECLINED, Models\STATUS_FRAUD))) {
+        if (!in_array($status, array(Models\STATUS_APPROVED, Models\STATUS_DECLINED, Models\STATUS_FRAUD, Models\STATUS_CANCELED, Models\STATUS_NOT_AUTHORIZED))) {
             throw new Exceptions\InvalidOrderException("status");
         }
 

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -4,6 +4,7 @@ const STATUS_PENDING         = "pending";
 const STATUS_APPROVED        = "approved";
 const STATUS_DECLINED        = "declined";
 const STATUS_FRAUD           = "fraud";
+const STATUS_CANCELED        = "canceled";
 const STATUS_NOT_AUTHORIZED  = "not_authorized";
 
 const RECOMMENDATION_APPROVE = "approve";


### PR DESCRIPTION
Add "canceled" and "not_authorized" statuses in update order method

http://docs.konduto.com/en/#update-order-status

Actually, the api needs "canceled" instead "cancelled", see below:

```
# PUT https://api.konduto.com/v1/orders/{ID}
{
    "message": {
        "where": "/status",
        "why": {
            "expected": [
                "approved",
                "declined",
                "fraud",
                "canceled",
                "not_authorized"
            ],
            "found": "cancelled"
        }
    },
    "status": "error"
}
```
