### PR TITLE
Suporte para o método de pagamento PIX

### DIFF
--- a/src/Models/Payment.php
+++ b/src/Models/Payment.php
@@ -7,13 +7,14 @@ class Payment extends BaseModel {
     const TYPE_DEBIT = "debit";
     const TYPE_TRANSFER = "transfer";
     const TYPE_VOUCHER = "voucher";
+    const TYPE_PIX = "pix";
 
     const STATUS_APPROVED = "approved";
     const STATUS_DECLINED = "declined";
     const STATUS_PENDING  = "pending";
 
     public static $availableTypes = array(self::TYPE_CREDIT, self::TYPE_BOLETO,
-        self::TYPE_DEBIT, self::TYPE_TRANSFER, self::TYPE_VOUCHER);
+        self::TYPE_DEBIT, self::TYPE_TRANSFER, self::TYPE_VOUCHER, self::TYPE_PIX);
 
     /**
      * @inheritdoc
@@ -43,6 +44,7 @@ class Payment extends BaseModel {
                 case Payment::TYPE_DEBIT:
                 case Payment::TYPE_TRANSFER:
                 case Payment::TYPE_VOUCHER:
+                case Payment::TYPE_PIX:
                     return new Payment($array);
                     break;
 

--- a/tests/unit/PaymentTest.php
+++ b/tests/unit/PaymentTest.php
@@ -50,4 +50,19 @@ class PaymentTest extends \PHPUnit_Framework_TestCase {
             "amount" => $voucher->getAmount()
         ), $arr);
     }
+
+    function test_pix() {
+        $pix = Payment::build(array(
+            "type" => "pix",
+            "description" => "12% discount",
+            "amount" => 13.90
+        ));
+        $arr = $pix->toJsonArray();
+        $this->assertInstanceOf('Konduto\Models\Payment', $pix);
+        $this->assertEquals(array(
+            "type" => $pix->getType(),
+            "description" => $pix->getDescription(),
+            "amount" => $pix->getAmount()
+        ), $arr);
+    }
 }


### PR DESCRIPTION
- `payment.type`
Pedidos com a forma de pagamento PIX recebiam o erro **Array must contain a valid 'type' field**